### PR TITLE
Mruk/fixed spawn based on user position

### DIFF
--- a/Assets/Scenes/Tiago/03-WipingDust-SelectPlayArea.unity
+++ b/Assets/Scenes/Tiago/03-WipingDust-SelectPlayArea.unity
@@ -16146,7 +16146,7 @@ MonoBehaviour:
   SurfaceClearanceDistance: 0.1
   parentToAnchor: 1
   allowStretch: 1
-  spawnBasedOn: 1
+  spawnBasedOn: 0
   snapTarget: 3
   clampLocalPositions: 1
   fixedLocalPositions:
@@ -18438,7 +18438,7 @@ MonoBehaviour:
   SurfaceClearanceDistance: 0.1
   parentToAnchor: 0
   allowStretch: 0
-  spawnBasedOn: 0
+  spawnBasedOn: 1
   snapTarget: 3
   clampLocalPositions: 1
   fixedLocalPositions:

--- a/Assets/Scenes/Tiago/03-WipingDust-SelectPlayArea.unity
+++ b/Assets/Scenes/Tiago/03-WipingDust-SelectPlayArea.unity
@@ -18440,7 +18440,7 @@ MonoBehaviour:
   allowStretch: 0
   spawnBasedOn: 1
   snapTarget: 3
-  clampLocalPositions: 1
+  clampLocalPositions: 0
   fixedLocalPositions:
   - {x: 0.1, y: 0.1}
   - {x: 0.2, y: 0.2}

--- a/Assets/Scenes/Tiago/03-WipingDust-SelectPlayArea.unity
+++ b/Assets/Scenes/Tiago/03-WipingDust-SelectPlayArea.unity
@@ -16130,6 +16130,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5db3fbf2947a92440b8269afc83c1dd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  centerEyeTransform: {fileID: 1088010140}
   gameAnchorSelection: {fileID: 1092795428}
   _gameAnchor: {fileID: 0}
   SpawnOnStart: 1
@@ -16145,6 +16146,9 @@ MonoBehaviour:
   SurfaceClearanceDistance: 0.1
   parentToAnchor: 1
   allowStretch: 1
+  spawnBasedOn: 1
+  snapTarget: 3
+  clampLocalPositions: 1
   fixedLocalPositions:
   - {x: 0, y: 0}
   shufflePositions: 0
@@ -18418,6 +18422,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4d839e2a287d6404eb91cf72874aa041, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  centerEyeTransform: {fileID: 1088010140}
   gameAnchorSelection: {fileID: 1092795428}
   _gameAnchor: {fileID: 0}
   SpawnOnStart: 1
@@ -18433,6 +18438,9 @@ MonoBehaviour:
   SurfaceClearanceDistance: 0.1
   parentToAnchor: 0
   allowStretch: 0
+  spawnBasedOn: 0
+  snapTarget: 3
+  clampLocalPositions: 1
   fixedLocalPositions:
   - {x: 0.1, y: 0.1}
   - {x: 0.2, y: 0.2}
@@ -25869,6 +25877,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ee88c56d6374f744aee1bc68b35c9f7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  centerEyeTransform: {fileID: 1088010140}
   gameAnchorSelection: {fileID: 1092795428}
   _gameAnchor: {fileID: 0}
   SpawnOnStart: 1

--- a/Assets/Scripts/MRUK/MRUK.Extension.cs
+++ b/Assets/Scripts/MRUK/MRUK.Extension.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using UnityEngine;
 using System.Linq;
 using Meta.XR.MRUtilityKit;
+using Unity.VisualScripting;
+using UnityEditor.Experimental.GraphView;
 
 
 namespace ChoreChampion.XR.MRUtilityKit
@@ -18,7 +20,7 @@ namespace ChoreChampion.XR.MRUtilityKit
         OnTopOfSurfaces, // Spawn on surfaces facing upwards such as ground, top of tables, beds, couches, etc...
         HangingDown // Spawn on surfaces facing downwards such as the ceiling
     }
-    public class MRUKExtension
+    public static class MRUKExtension
     {
         /// <summary>
         /// Public copy Surface used in MRUK (it is internal only there)
@@ -61,7 +63,8 @@ namespace ChoreChampion.XR.MRUtilityKit
 
 
         /// <summary>
-        /// FROM MRUKRoom.cs - extracted from GenerateRandomPositionOnSurface - since we are using the same anchor over and over again, no need to calculate it every time
+        /// FROM MRUKRoom.cs - extracted from GenerateRandomPositionOnSurface - since we are using the same anchor over and over again, no need to calculate it every time.
+        /// In our case: I don't want a plane rect in a volume bound for now
         /// </summary>
         /// <param name="surfaceTypes"></param>
         /// <param name="minDistanceToEdge"></param>
@@ -69,51 +72,13 @@ namespace ChoreChampion.XR.MRUtilityKit
         /// <param name="totalUsableSurfaceArea"></param>
         /// <returns></returns>
         /// <exception cref="System.Exception"></exception>
+        /// ???: we may some issues with the code because we ignore the planeRect surface in a volume bound (which I guess is the on top) 
         public static List<Surface> GetAnchorSurfaces(MRUK.SurfaceType surfaceTypes, float minDistanceToEdge, MRUKAnchor anchor, ref float totalUsableSurfaceArea)
         {
             List<Surface> surfaces = new();
             float minWidth = 2f * minDistanceToEdge;
-            if (anchor.PlaneRect.HasValue)
-            {
-                bool skipPlane = false;
-                if (anchor.transform.forward.y >= Utilities.InvSqrt2)
-                {
-                    if ((surfaceTypes & MRUK.SurfaceType.FACING_UP) == 0)
-                    {
-                        skipPlane = true;
-                    }
-                }
-                else if (anchor.transform.forward.y <= -Utilities.InvSqrt2)
-                {
-                    if ((surfaceTypes & MRUK.SurfaceType.FACING_DOWN) == 0)
-                    {
-                        skipPlane = true;
-                    }
-                }
-                else if ((surfaceTypes & MRUK.SurfaceType.VERTICAL) == 0)
-                {
-                    skipPlane = true;
-                }
 
-                if (!skipPlane)
-                {
-                    var size = anchor.PlaneRect.Value.size;
-                    if (size.x > minWidth && size.y > minWidth)
-                    {
-                        var usableArea = (size.x - minWidth) * (size.y - minWidth);
-                        totalUsableSurfaceArea += usableArea;
-                        surfaces.Add(new()
-                        {
-                            Anchor = anchor,
-                            UsableArea = usableArea,
-                            IsPlane = true,
-                            Bounds = anchor.PlaneRect.Value,
-                            Transform = anchor.transform.localToWorldMatrix
-                        });
-                    }
-                }
-            }
-
+            Debug.Log($"[{nameof(GetAnchorSurfaces)}] Anchor {anchor.name}, Has PlaneRect: {anchor.PlaneRect.HasValue}, Has VolumeBounds: {anchor.VolumeBounds.HasValue}, components {anchor}");
             if (anchor.VolumeBounds.HasValue)
             {
                 for (int i = 0; i < 6; ++i)
@@ -227,8 +192,309 @@ namespace ChoreChampion.XR.MRUtilityKit
                     }
                 }
             }
+            else if (anchor.PlaneRect.HasValue)
+            {
+                bool skipPlane = false;
+                if (anchor.transform.forward.y >= Utilities.InvSqrt2)
+                {
+                    if ((surfaceTypes & MRUK.SurfaceType.FACING_UP) == 0)
+                    {
+                        skipPlane = true;
+                    }
+                }
+                else if (anchor.transform.forward.y <= -Utilities.InvSqrt2)
+                {
+                    if ((surfaceTypes & MRUK.SurfaceType.FACING_DOWN) == 0)
+                    {
+                        skipPlane = true;
+                    }
+                }
+                else if ((surfaceTypes & MRUK.SurfaceType.VERTICAL) == 0)
+                {
+                    skipPlane = true;
+                }
+
+                if (!skipPlane)
+                {
+                    var size = anchor.PlaneRect.Value.size;
+                    if (size.x > minWidth && size.y > minWidth)
+                    {
+                        var usableArea = (size.x - minWidth) * (size.y - minWidth);
+                        totalUsableSurfaceArea += usableArea;
+                        surfaces.Add(new()
+                        {
+                            Anchor = anchor,
+                            UsableArea = usableArea,
+                            IsPlane = true,
+                            Bounds = anchor.PlaneRect.Value,
+                            Transform = anchor.transform.localToWorldMatrix
+                        });
+                    }
+                }
+            }
 
             return surfaces;
+        }
+
+        public enum SnapTarget
+        {
+            None = 0, // Default behavior: clamp to surface bounds (interior)
+            Corner = 1, // Force snap to the nearest corner of the surface bounds
+            Center = 2, // Force snap to the exact center of the surface bounds
+            NearestEdge = 3, // Snap to the nearest edge of the surface bounds (X or Z), clamping the other axis
+            CenterLine = 4, // Align the closest axis (X or Z) to bounds center; clamp the other inside
+            EdgeWithCenterLine = 5 // Snap to nearest edge, and center-align the other axis
+        }
+
+        public enum Clamp2DValues
+        {
+            None = 0,
+            X = 1,
+            Y = 2,
+            XandY = 3
+        }
+
+        /// <summary>
+        /// Finds the closest edge position to the surface provided, providing a given point, the position, normal at that position, and the distance.
+        /// </summary>
+        /// <param name="surface">The surface in which I doing this calculus based on the position to test</param>
+        /// <param name="testPosition">The position to test.</param>
+        /// <param name="minDistanceToEdge">minimum distance of any edge</param>
+        /// <param name="mappedPosition"></param>
+        /// <param name="closestPosition">The closest position on the surface.</param>
+        /// <param name="normal">The normal at the closest position.</param>
+        /// <param name="snapTarget">Enum to specify where it should snap object</param>
+        /// <param name="clampOffsetToBounds">whether to restrict final offset point to surface bounds</param>
+        /// <returns>The distance to the closest surface position.</returns>
+        /// <exception cref="Exception">Snap target case not found</exception>
+        public static float GetClosestPositionToSurface(this Surface surface, Vector3 testPosition, float minDistanceToEdge, out Vector2 mappedPosition, out Vector3 closestPosition, out Vector3 normal, SnapTarget snapTarget, Vector2? localOffset = null, Clamp2DValues clampOffsetToBounds = Clamp2DValues.None)
+        {
+            float candidateDistance = Mathf.Infinity;
+            closestPosition = Vector3.zero;
+
+            // Surface normal (always transform.forward of surface)
+            normal = surface.Transform.MultiplyVector(Vector3.forward).normalized;
+            mappedPosition = Vector2.zero;
+
+            MRUKAnchor anchor = surface.Anchor;
+
+            // Convert test position to local surface space
+            Vector3 localPosition = surface.Transform.inverse.MultiplyPoint3x4(testPosition);
+            //Vector3 localPosition = anchor.transform.InverseTransformPoint(testPosition);
+
+            Debug.Log($"[{nameof(GetClosestPositionToSurface)}] - Anchor: {anchor.name}, HasVolumeBound {anchor.VolumeBounds.HasValue}, HasPlaneBound {anchor.PlaneRect.HasValue}, WorldPosition {testPosition}, LocalPosition {localPosition}, normal {normal}, localOffset: {localOffset}");
+            if (anchor.VolumeBounds.HasValue) // is volume
+            {
+                // bounds with minimum distance to edge included (for easier calculations)
+                Rect surfaceBounds = CreateRectWithMinimumDistanceToEdge(surface.Bounds, minDistanceToEdge);
+                // Project onto the XZ plane of the surface (Y is fixed at surface height)
+                Vector2 local2D = new(localPosition.x, localPosition.y);
+
+                // Clamp to rect by default (safe fallback)
+                Vector2 clamped2D;
+
+                Debug.Log($"[{nameof(GetClosestPositionToSurface)}] - Volume Start Bounds: {surfaceBounds}");
+                Debug.Log($"[{nameof(GetClosestPositionToSurface)}] - Volume Start initial values: local2D - {local2D}");
+
+
+                // Resolve snapping behavior
+                switch (snapTarget)
+                {
+                    case SnapTarget.Corner:
+                        // Snap to nearest corner
+                        clamped2D = new(
+                            (Mathf.Abs(local2D.x - surfaceBounds.xMin) < Mathf.Abs(local2D.x - surfaceBounds.xMax)) ? surfaceBounds.xMin : surfaceBounds.xMax,
+                            (Mathf.Abs(local2D.y - surfaceBounds.yMin) < Mathf.Abs(local2D.y - surfaceBounds.yMax)) ? surfaceBounds.yMin : surfaceBounds.yMax
+                        );
+                        break;
+
+                    case SnapTarget.Center:
+                        // Snap to rect center
+                        clamped2D = surfaceBounds.center;
+                        break;
+
+                    case SnapTarget.NearestEdge:
+                        // Snap to nearest edge
+                        clamped2D = SnapToNearestEdge(local2D, surfaceBounds);
+                        break;
+
+                    case SnapTarget.CenterLine:
+                        // Align one axis to rect center
+                        clamped2D = ApplyCenterAlignment(local2D, surfaceBounds);
+                        break;
+
+                    case SnapTarget.EdgeWithCenterLine:
+                        // First snap to nearest edge
+                        clamped2D = SnapToNearestEdge(local2D, surfaceBounds);
+                        // Then align remaining axis to center
+                        clamped2D = ApplyCenterAlignment(clamped2D, surfaceBounds);
+                        break;
+
+                    case SnapTarget.None:
+                        clamped2D = new(
+                            Mathf.Clamp(local2D.x, surfaceBounds.xMin, surfaceBounds.xMax),
+                            Mathf.Clamp(local2D.y, surfaceBounds.yMin, surfaceBounds.yMax)
+                        );
+                        break;
+
+                    default:
+                        throw new Exception($"[{nameof(SnapTarget)}] - option missing");
+                }
+
+                Vector2 center2D = surfaceBounds.center;
+
+                // Direction to center in Y (vertical axis)
+                Vector2 dirToCenter = (center2D - local2D).normalized;
+
+                int forwardDir = dirToCenter.y >= 0f ? 1 : -1;
+                
+                // NOTE: couldn't make it to work to go right by default, so we do it based on dirToCenter.x
+                int rightDir = dirToCenter.x >= 0f ? 1 : -1;
+                
+                // ???: part of code always go to the right is not working
+                /*
+                // corner needs to always to go towards the center
+                if (snapTarget == SnapTarget.Corner)
+                {
+                    // Evaluate horizontal direction to center
+                    rightDir = (dirToCenter.x >= 0f ? 1 : -1);
+                } 
+                else
+                {
+                    // 90 rotated from forward
+                    // ???: there might be an issue here if we want always to go towards the right
+                    rightDir = -forwardDir;//(dirToCenter.x * forwardDir >= 0f) ? -1 : 1;
+                }
+                */
+
+                Vector2 offsetAxis = new(rightDir, forwardDir);
+
+                Vector2 auxOffset = localOffset != null ? (Vector2)localOffset : Vector2.zero;
+                Vector2 offset = new (auxOffset.x * offsetAxis.x, auxOffset.y * offsetAxis.y);
+
+                clamped2D += offset;
+
+                // to make sure the offset is clamped
+                if (clampOffsetToBounds != Clamp2DValues.None)
+                {
+                    var clampedX = clamped2D.x;
+                    var clampedY = clamped2D.y;
+
+                    if (clampOffsetToBounds == Clamp2DValues.X || clampOffsetToBounds == Clamp2DValues.XandY)
+                    {
+                        clampedX = Mathf.Clamp(clamped2D.x, surfaceBounds.xMin, surfaceBounds.xMax);
+                    }
+                    if (clampOffsetToBounds == Clamp2DValues.Y || clampOffsetToBounds == Clamp2DValues.XandY)
+                    {
+                        clampedY = Mathf.Clamp(clamped2D.y, surfaceBounds.xMin, surfaceBounds.xMax);
+                    }
+                    
+                    clamped2D = new ( clampedX, clampedY );
+                }
+
+                // Rebuild world position from local 2D
+                Vector3 localClosestPoint = new(clamped2D.x, clamped2D.y, 0f);
+                closestPosition = surface.Transform.MultiplyPoint3x4(localClosestPoint);
+
+                // Final distance from test point to chosen surface point
+                candidateDistance = Vector3.Distance(closestPosition, testPosition);
+
+                mappedPosition = clamped2D;
+
+                Debug.Log($"[{nameof(GetClosestPositionToSurface)}] - Volume Result: clamped2D - {mappedPosition}, closestPosition {closestPosition}, distance {candidateDistance}");
+
+                // ???: unsure this is correct - not tested/not important
+                //if (volumeBounds.Contains(localPosition))
+
+            }
+            else
+            {
+                var planeRect = anchor.PlaneRect.Value;
+                localPosition.z = 0;
+
+                if (localPosition.x > planeRect.max.x)
+                {
+                    localPosition.x = planeRect.max.x;
+                }
+                else if (localPosition.x < planeRect.min.x)
+                {
+                    localPosition.x = planeRect.min.x;
+                }
+
+                if (localPosition.y > planeRect.max.y)
+                {
+                    localPosition.y = planeRect.max.y;
+                }
+                else if (localPosition.y < planeRect.min.y)
+                {
+                    localPosition.y = planeRect.min.y;
+                }
+                var offset = localOffset != null ? new Vector3(((Vector2)localOffset).x, ((Vector2)localOffset).y, 0f) : Vector3.zero;
+
+                localPosition += offset;
+
+                closestPosition = anchor.transform.TransformPoint(localPosition);
+                candidateDistance = Vector3.Distance(closestPosition, testPosition);
+                mappedPosition = new(localPosition.x, localPosition.y);
+
+                Debug.Log($"[{nameof(GetClosestPositionToSurface)}] - Plane Result: clamped2D - {mappedPosition}, closestPosition {closestPosition}, distance {candidateDistance}");
+            }
+
+            return candidateDistance;
+        }
+
+        // Snap to nearest edge of the rect, based on direction from center
+        private static Vector2 SnapToNearestEdge(Vector2 local2D, Rect rect)
+        {
+            Vector2 center = rect.center;
+            Vector2 delta = local2D - center;
+
+            // Decide dominant axis from center to test point
+            if (Mathf.Abs(delta.x) > Mathf.Abs(delta.y))
+            {
+                // X is dominant → snap X to edge, clamp Y
+                float edgeX = (delta.x < 0f) ? rect.xMin : rect.xMax;
+                float clampedY = Mathf.Clamp(local2D.y, rect.yMin, rect.yMax);
+                return new Vector2(edgeX, clampedY);
+            }
+            else
+            {
+                // Y is dominant → snap Y to edge, clamp X
+                float edgeY = (delta.y < 0f) ? rect.yMin : rect.yMax;
+                float clampedX = Mathf.Clamp(local2D.x, rect.xMin, rect.xMax);
+                return new Vector2(clampedX, edgeY);
+            }
+        }
+
+        // Align closest axis to center of rect, based on direction from center
+        private static Vector2 ApplyCenterAlignment(Vector2 local2D, Rect rect)
+        {
+            Vector2 center = rect.center;
+            Vector2 delta = local2D - center;
+
+            if (Mathf.Abs(delta.x) < Mathf.Abs(delta.y))
+            {
+                // X is closer to center → align X to center, clamp Y
+                float clampedY = Mathf.Clamp(local2D.y, rect.yMin, rect.yMax);
+                return new Vector2(center.x, clampedY);
+            }
+            else
+            {
+                // Y is closer to center → align Y to center, clamp X
+                float clampedX = Mathf.Clamp(local2D.x, rect.xMin, rect.xMax);
+                return new Vector2(clampedX, center.y);
+            }
+        }
+
+        public static Rect CreateRectWithMinimumDistanceToEdge(Rect rect, float minDistanceToEdge)
+        {
+            // NOTE: If minDistanceToEdge is too large (greater than half the width or height), the resulting Rect may have negative width/height.
+            var newRect = new Rect(rect);
+            newRect.xMin += minDistanceToEdge;
+            newRect.yMin += minDistanceToEdge;
+            newRect.xMax -= minDistanceToEdge;
+            newRect.yMax -= minDistanceToEdge;
+            return newRect;
         }
     }
 

--- a/Assets/Scripts/MRUK/SpawnPrefabs/BaseSpawnPrefabsOnAnchorSurfaces.cs
+++ b/Assets/Scripts/MRUK/SpawnPrefabs/BaseSpawnPrefabsOnAnchorSurfaces.cs
@@ -473,21 +473,6 @@ namespace ChoreChampion.XR.MRUtilityKit
             // TODO: Right now only works on a single surface (the first one). Extend code in the future
             var surface = anchorSurfacesList[0];
             surface.GetClosestPositionToSurface(centerEyeTransform.position, _minRadius, out var mappedPosition, out position, out normal, snapTarget, localPosition, clampLocation);
-
-            // you get the closest local surface 2d vector, and you add the local position 
-            //mappedPosition = new Vector2(mappedPosition.x + localPosition.x, mappedPosition.y + localPosition.y);
-            //position = surface.Transform.MultiplyPoint3x4(new(mappedPosition.x, mappedPosition.y, 0f));
-            // TODO: only works for on top of surfaces right now
-            //position += new Vector3(localPosition.x, 0f, localPosition.y);
-            //normal = surface.Transform.MultiplyVector(Vector3.forward);
-            /*
-            if (surface.IsPlane && !surface.Anchor.IsPositionInBoundary(mappedPosition))
-            {
-                position = Vector3.zero;
-                normal = Vector3.zero;
-                return false;
-            }
-            */
             return true;
         }
 

--- a/Assets/Scripts/MRUK/SpawnPrefabs/BaseSpawnPrefabsOnAnchorSurfaces.cs
+++ b/Assets/Scripts/MRUK/SpawnPrefabs/BaseSpawnPrefabsOnAnchorSurfaces.cs
@@ -24,6 +24,11 @@ namespace ChoreChampion.XR.MRUtilityKit
             public float TotalUsableSurfaceArea;
         }
 
+        /// <summary>
+        /// Reference to the center eye transform (user's head position).
+        /// </summary>
+        [SerializeField] protected Transform centerEyeTransform;
+
         [Tooltip("Class that selects Game Anchor.")]
         [SerializeField] protected GameAnchorSelection gameAnchorSelection;
 
@@ -118,7 +123,8 @@ namespace ChoreChampion.XR.MRUtilityKit
         protected int _currentSpawnedObjects;
         public int CurrentSpawnedObjects => _currentSpawnedObjects;
 
-        protected void OnValidate()
+
+        protected virtual void OnValidate()
         {
             if (gameAnchorSelection == null)
             {
@@ -126,6 +132,24 @@ namespace ChoreChampion.XR.MRUtilityKit
                 if (gameAnchorSelection == null)
                 {
                     Debug.LogError($"[{GetType()}] - ERROR: requires {nameof(GameAnchorSelection)} object in game");
+                }
+            }
+
+            // Find center eye transform - prioritize "CenterEyeAnchor" GameObject, fallback to first Camera
+            if (centerEyeTransform == null)
+            {
+                GameObject centerEyeAnchor = GameObject.Find("CenterEyeAnchor");
+                if (centerEyeAnchor != null)
+                {
+                    centerEyeTransform = centerEyeAnchor.transform;
+                }
+                else
+                {
+                    GameObject firstCamera = GameObject.FindWithTag("MainCamera");
+                    if (firstCamera != null)
+                    {
+                        centerEyeTransform = firstCamera.transform;
+                    }
                 }
             }
         }
@@ -204,7 +228,7 @@ namespace ChoreChampion.XR.MRUtilityKit
                 float totalUsableSurfaceArea = 0f;
 
                 // FIXME: minDistance to edge?
-                var anchorSurfacesList = MRUKExtension.GetAnchorSurfaces(surfaceTypes, _minRadius, anchor, ref totalUsableSurfaceArea);
+                List<MRUKExtension.Surface> anchorSurfacesList = GetAnchorSurfaces(surfaceTypes, anchor, ref totalUsableSurfaceArea);
                 if (anchorSurfacesList.Count == 0)
                 {
                     Debug.LogWarning($"[{GetType().Name} - {nameof(BuildAnchorsSurfaceDataDictionary)}]: Anchor {anchor.name} does not have surfaces!");
@@ -220,6 +244,11 @@ namespace ChoreChampion.XR.MRUtilityKit
                     }
                 );
             }
+        }
+
+        protected virtual List<MRUKExtension.Surface> GetAnchorSurfaces(MRUK.SurfaceType surfaceTypes, MRUKAnchor anchor, ref float totalUsableSurfaceArea)
+        {
+            return MRUKExtension.GetAnchorSurfaces(surfaceTypes, _minRadius, anchor, ref totalUsableSurfaceArea);
         }
 
         /// <summary>
@@ -345,20 +374,6 @@ namespace ChoreChampion.XR.MRUtilityKit
             var anchorSurfacesList = surfaceData.SurfaceList;
             var totalUsableSurfaceArea = surfaceData.TotalUsableSurfaceArea;
 
-            /*
-            if (!InitializeAnchorSurfaces(surfaceTypes, minDistanceToEdge, anchor, out var anchorSurfacesList))
-            {
-                return false;
-            }
-            
-
-            float totalUsableSurfaceArea = 0f;
-            for (int i = 0; i < anchorSurfacesList.Count; i++)
-            {
-                totalUsableSurfaceArea += anchorSurfacesList[i].UsableArea;
-            }
-            */
-
             for (int i = 0; i < MaxIterations; ++i)
             {
                 // Pick a random surface weighted by surface area (anchorSurfacesList with a larger
@@ -417,15 +432,6 @@ namespace ChoreChampion.XR.MRUtilityKit
             }
             var surfaceData = anchorsSurfaceData[anchor];
             var anchorSurfacesList = surfaceData.SurfaceList;
-            var totalUsableSurfaceArea = surfaceData.TotalUsableSurfaceArea;
-
-            /*
-            // FIXME: ignoring minDistanceToEdge right now due to rotation issues ahead
-            if (!InitializeAnchorSurfaces(surfaceTypes, 0f, anchor, out var anchorSurfacesList))
-            {
-                return false;
-            }
-            */
 
             // TODO: Right now only works on a single surface (the first one). Extend code in the future.
             // Use the first surface for fixed positioning (or could be made configurable)
@@ -435,8 +441,8 @@ namespace ChoreChampion.XR.MRUtilityKit
             // Lerp local position from [-0.5, 0.5] range to bounds coordinates respecting minDistanceToEdge
             // localPosition.x = -0.5 maps to bounds.xMin + minDistanceToEdge
             // localPosition.x = 0.5 maps to bounds.xMax - minDistanceToEdge
-            float mappedX = Mathf.Lerp(bounds.xMin + 0f, bounds.xMax - 0f, localPosition.x + 0.5f);
-            float mappedY = Mathf.Lerp(bounds.yMin + 0f, bounds.yMax - 0f, localPosition.y + 0.5f);
+            float mappedX = Mathf.Lerp(bounds.xMin + minDistanceToEdge, bounds.xMax - minDistanceToEdge, localPosition.x + 0.5f);
+            float mappedY = Mathf.Lerp(bounds.yMin + minDistanceToEdge, bounds.yMax - minDistanceToEdge, localPosition.y + 0.5f);
 
             Vector2 mappedPosition = new Vector2(mappedX, mappedY);
 
@@ -445,8 +451,43 @@ namespace ChoreChampion.XR.MRUtilityKit
                 return false;
             }
 
-            position = surface.Transform.MultiplyPoint3x4(new (mappedPosition.x, mappedPosition.y, 0f));
+            position = surface.Transform.MultiplyPoint3x4(new(mappedPosition.x, mappedPosition.y, 0f));
             normal = surface.Transform.MultiplyVector(Vector3.forward);
+            return true;
+        }
+
+        // similar to fixed, but in this case it is based on the closest position to vector provided
+        public virtual bool GenerateClosestPositionOnSpecificSurfaceAnchor(MRUK.SurfaceType surfaceTypes, Vector2 localPosition, float minDistanceToEdge, MRUKAnchor anchor, out Vector3 position, out Vector3 normal, MRUKExtension.SnapTarget snapTarget, MRUKExtension.Clamp2DValues clampLocation)
+        {
+            // define these as the negative early exit conditions
+            position = Vector3.zero;
+            normal = Vector3.zero;
+
+            if (!anchorsSurfaceData.ContainsKey(anchor))
+            {
+                return false;
+            }
+            var surfaceData = anchorsSurfaceData[anchor];
+            var anchorSurfacesList = surfaceData.SurfaceList;
+
+            // TODO: Right now only works on a single surface (the first one). Extend code in the future
+            var surface = anchorSurfacesList[0];
+            surface.GetClosestPositionToSurface(centerEyeTransform.position, _minRadius, out var mappedPosition, out position, out normal, snapTarget, localPosition, clampLocation);
+
+            // you get the closest local surface 2d vector, and you add the local position 
+            //mappedPosition = new Vector2(mappedPosition.x + localPosition.x, mappedPosition.y + localPosition.y);
+            //position = surface.Transform.MultiplyPoint3x4(new(mappedPosition.x, mappedPosition.y, 0f));
+            // TODO: only works for on top of surfaces right now
+            //position += new Vector3(localPosition.x, 0f, localPosition.y);
+            //normal = surface.Transform.MultiplyVector(Vector3.forward);
+            /*
+            if (surface.IsPlane && !surface.Anchor.IsPositionInBoundary(mappedPosition))
+            {
+                position = Vector3.zero;
+                normal = Vector3.zero;
+                return false;
+            }
+            */
             return true;
         }
 

--- a/Assets/Scripts/MRUK/SpawnPrefabs/FixedSpawnPrefabsOnAnchorSurfaces.cs
+++ b/Assets/Scripts/MRUK/SpawnPrefabs/FixedSpawnPrefabsOnAnchorSurfaces.cs
@@ -26,7 +26,7 @@ namespace ChoreChampion.XR.MRUtilityKit
         protected MRUKExtension.SnapTarget snapTarget = MRUKExtension.SnapTarget.NearestEdge;
 
         [SerializeField, Tooltip("On spawn based on user position, given the local position provided, clamp value in axis"), HideIf(nameof(spawnBasedOn), SpawnBasedOn.AnchorTransform)]
-        protected MRUKExtension.Clamp2DValues clampLocalPositions = MRUKExtension.Clamp2DValues.X;
+        protected MRUKExtension.Clamp2DValues clampLocalPositions = MRUKExtension.Clamp2DValues.None;
 
         /// <summary>
         /// List of fixed local positions to spawn prefabs at. Cycles through this list when spawn amount exceeds list size.

--- a/Assets/Scripts/MRUK/SpawnPrefabs/FixedSpawnPrefabsOnAnchorSurfaces.cs
+++ b/Assets/Scripts/MRUK/SpawnPrefabs/FixedSpawnPrefabsOnAnchorSurfaces.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using System.Collections.Generic;
 using Meta.XR.MRUtilityKit;
+using NaughtyAttributes;
 
 namespace ChoreChampion.XR.MRUtilityKit
 {
@@ -11,19 +12,20 @@ namespace ChoreChampion.XR.MRUtilityKit
     {
         protected enum SpawnBasedOn
         {
-            UserPosition = 0,
-            AnchorTransform = 1
+            
+            AnchorTransform = 0,
+            UserPosition = 1
         }
 
         [Space]
         [Header("Fixed Spawn Variables")]
         [SerializeField, Tooltip("Spawn things based on user position or Anchor transform")]
-        protected SpawnBasedOn spawnBasedOn = SpawnBasedOn.UserPosition;
+        protected SpawnBasedOn spawnBasedOn;
 
-        [SerializeField, Tooltip("On spawn based on user position, where it should spawn")]
+        [SerializeField, Tooltip("On spawn based on user position, where it should spawn"), HideIf(nameof(spawnBasedOn), SpawnBasedOn.AnchorTransform)]
         protected MRUKExtension.SnapTarget snapTarget = MRUKExtension.SnapTarget.NearestEdge;
 
-        [SerializeField, Tooltip("Based on local position provided, clamp value in axis if needed")]
+        [SerializeField, Tooltip("On spawn based on user position, given the local position provided, clamp value in axis"), HideIf(nameof(spawnBasedOn), SpawnBasedOn.AnchorTransform)]
         protected MRUKExtension.Clamp2DValues clampLocalPositions = MRUKExtension.Clamp2DValues.X;
 
         /// <summary>

--- a/Assets/Scripts/MRUK/SpawnPrefabs/FixedSpawnPrefabsOnAnchorSurfaces.cs
+++ b/Assets/Scripts/MRUK/SpawnPrefabs/FixedSpawnPrefabsOnAnchorSurfaces.cs
@@ -9,6 +9,23 @@ namespace ChoreChampion.XR.MRUtilityKit
     /// </summary>
     public class FixedSpawnPrefabsOnAnchorSurfaces : BaseSpawnPrefabsOnAnchorSurfaces
     {
+        protected enum SpawnBasedOn
+        {
+            UserPosition = 0,
+            AnchorTransform = 1
+        }
+
+        [Space]
+        [Header("Fixed Spawn Variables")]
+        [SerializeField, Tooltip("Spawn things based on user position or Anchor transform")]
+        protected SpawnBasedOn spawnBasedOn = SpawnBasedOn.UserPosition;
+
+        [SerializeField, Tooltip("On spawn based on user position, where it should spawn")]
+        protected MRUKExtension.SnapTarget snapTarget = MRUKExtension.SnapTarget.NearestEdge;
+
+        [SerializeField, Tooltip("Based on local position provided, clamp value in axis if needed")]
+        protected MRUKExtension.Clamp2DValues clampLocalPositions = MRUKExtension.Clamp2DValues.X;
+
         /// <summary>
         /// List of fixed local positions to spawn prefabs at. Cycles through this list when spawn amount exceeds list size.
         /// </summary>
@@ -37,8 +54,9 @@ namespace ChoreChampion.XR.MRUtilityKit
         [SerializeField, Tooltip("Incremental offset adjustment per iteration on the normal direction.")]
         protected float incrementalOffsetPerIteration = 0.002f;
 
-        protected virtual void OnValidate()
+        protected override void OnValidate()
         {
+            base.OnValidate();
             MaxIterations = 10; // since positions are fixed it does not make sense to iterate further
         }
 
@@ -62,10 +80,11 @@ namespace ChoreChampion.XR.MRUtilityKit
         /// <returns>True if position was calculated successfully, false otherwise.</returns>
         protected override bool CalculateSpawnPositionAndNormal(MRUK.SurfaceType surfaceType, MRUKAnchor anchor, out Vector3 spawnPosition, out Vector3 spawnNormal, int iteration = 0)
         {
+            spawnPosition = Vector3.zero;
+            spawnNormal = Vector3.zero;
+
             if (fixedLocalPositions.Count == 0)
             {
-                spawnPosition = Vector3.zero;
-                spawnNormal = Vector3.zero;
                 return false;
             }
 
@@ -81,8 +100,8 @@ namespace ChoreChampion.XR.MRUtilityKit
                 ShufflePositions();
             }
 
-            // Use fixed positioning
-            if (GenerateFixedPositionOnSpecificSurfaceAnchor(surfaceType, localPosition, _minRadius, anchor, out var pos, out var normal))
+            // 
+            if (TryGeneratePositionOnSpecificSurfaceAnchor(surfaceType, anchor, out Vector3 pos, out Vector3 normal, iteration, localPosition))
             {
                 // Calculate incremental offset based on iteration
                 float incrementalOffset = iteration * incrementalOffsetPerIteration;
@@ -91,9 +110,22 @@ namespace ChoreChampion.XR.MRUtilityKit
                 return true;
             }
 
-            spawnPosition = Vector3.zero;
-            spawnNormal = Vector3.zero;
             return false;
+        }
+
+        // In my extensions this will be the bit that changes
+        protected virtual bool TryGeneratePositionOnSpecificSurfaceAnchor(MRUK.SurfaceType surfaceType, MRUKAnchor anchor, out Vector3 pos, out Vector3 normal, int iteration, Vector2 localPosition)
+        {
+            if (spawnBasedOn == SpawnBasedOn.AnchorTransform)
+            {
+                // This case: Use fixed positioning based on anchor local space
+                return GenerateFixedPositionOnSpecificSurfaceAnchor(surfaceType, localPosition, _minRadius, anchor, out pos, out normal);
+            }
+            else
+            {
+                return GenerateClosestPositionOnSpecificSurfaceAnchor(surfaceType, localPosition, _minRadius, anchor, out pos, out normal, snapTarget, clampLocalPositions);
+            }
+
         }
 
         /// <summary>

--- a/Assets/Scripts/MRUK/SpawnPrefabs/PlaceAndStretchSingleObjectOnAnchor.cs
+++ b/Assets/Scripts/MRUK/SpawnPrefabs/PlaceAndStretchSingleObjectOnAnchor.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using Meta.XR.MRUtilityKit;
 using System.Linq;
+using System.Collections.Generic;
 
 namespace ChoreChampion.XR.MRUtilityKit
 {
@@ -13,6 +14,7 @@ namespace ChoreChampion.XR.MRUtilityKit
         protected override void OnValidate()
         {
             base.OnValidate();
+            spawnBasedOn = SpawnBasedOn.AnchorTransform;
             // Force single object placement
             SpawnAmountPerSurface = 1;
             // Force parenting and stretching
@@ -32,34 +34,10 @@ namespace ChoreChampion.XR.MRUtilityKit
             }
         }
 
-        /// <summary>
-        /// Every anchor that may use this - needs the list of surfaces where objects may spawn and the toal usable surface area (for random spawns)
-        /// </summary>
-        protected override void BuildAnchorsSurfaceDataDictionary()
+        protected override List<MRUKExtension.Surface> GetAnchorSurfaces(MRUK.SurfaceType surfaceTypes, MRUKAnchor anchor, ref float totalUsableSurfaceArea)
         {
-            anchorsSurfaceData = new();
-
-            foreach (var keyPair in gameAnchorSelection.AnchorPrefabSpawnerObjects)
-            {
-                MRUKAnchor anchor = keyPair.Key;
-                float totalUsableSurfaceArea = 0f;
-
-                // FIXME: minDistance to edge => issue on stretching - if you stretch there is no minDistance to edge
-                var anchorSurfacesList = MRUKExtension.GetAnchorSurfaces(GetSurfaceTypes(), 0f, anchor, ref totalUsableSurfaceArea);
-                if (anchorSurfacesList.Count == 0)
-                {
-                    Debug.LogWarning($"[{GetType().Name} - {nameof(BuildAnchorsSurfaceDataDictionary)}]: Anchor {anchor.name} does not have surfaces!");
-                    continue;
-                }
-
-                anchorsSurfaceData.Add(key: anchor,
-                    value: new AnchorSurfaceData
-                    {
-                        SurfaceList = anchorSurfacesList,
-                        TotalUsableSurfaceArea = totalUsableSurfaceArea
-                    }
-                );
-            }
+            // set minDistanceToEdge 0f to avoid issue with stretching (otherwise it fails)
+            return MRUKExtension.GetAnchorSurfaces(surfaceTypes, 0f, anchor, ref totalUsableSurfaceArea);
         }
     }
 }

--- a/Assets/Scripts/MRUK/SpawnPrefabs/RandomSpawnPrefabsOnAnchorSurfaces.cs
+++ b/Assets/Scripts/MRUK/SpawnPrefabs/RandomSpawnPrefabsOnAnchorSurfaces.cs
@@ -46,16 +46,16 @@ namespace ChoreChampion.XR.MRUtilityKit
         /// <param name="iteration">Current iteration number for incremental offset calculation. (ignored in this one)</param>
         /// <returns>True if position was calculated successfully, false otherwise.</returns>
         protected override bool CalculateSpawnPositionAndNormal(MRUK.SurfaceType surfaceType, MRUKAnchor anchor, out Vector3 spawnPosition, out Vector3 spawnNormal, int iteration = 0)
-        {
+        {         
+            spawnPosition = Vector3.zero;
+            spawnNormal = Vector3.zero;
+
             if (GenerateRandomPositionOnSpecificSurfaceAnchor(surfaceType, _minRadius, anchor, out var pos, out var normal))
             {
                 spawnPosition = pos + normal * _baseOffset;
                 spawnNormal = normal;
                 return true;
             }
-            
-            spawnPosition = Vector3.zero;
-            spawnNormal = Vector3.zero;
             return false;
         }
     }


### PR DESCRIPTION
- Added possibility to set a prefab position based on user's position (and closest point/edge/mid-table/table center whatever) with offset. 
- To make use of this: use spawnBased on: UserPosition
- This implementation can also clamp things so that they don't leave along the edge (Clamp - x axis) or perpendicular towards the center (y axis) 